### PR TITLE
Reduce image size from 21.4MB to 5.39MB (-75%)

### DIFF
--- a/action-base.Dockerfile
+++ b/action-base.Dockerfile
@@ -27,7 +27,7 @@ ADD action-base.list /etc/apt/sources.list.d/docker.list
 
 RUN apt-get update ;\
 	apt-get install --no-install-{recommends,suggests} -y \
-		docker-ce-cli nodejs ;\
+		docker-ce-cli nodejs upx ;\
 	apt-get clean ;\
 	rm -vrf /var/lib/apt/lists/*
 

--- a/action.bash
+++ b/action.bash
@@ -8,7 +8,9 @@ mkimg () {
 
 	node /actions/checkout/dist/index.js |grep -vFe ::add-matcher::
 
-	CGO_ENABLED=0 go build -o icingadb .
+	CGO_ENABLED=0 go build -ldflags '-s -w' -o icingadb .
+	upx icingadb
+
 	docker build -f /Dockerfile -t "${TARGET}:$TAG" .
 
 	STATE_isPost=1 node /actions/checkout/dist/index.js

--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:alpine as entrypoint
+RUN ["sh", "-exo", "pipefail", "-c", "apk add upx; rm -vf /var/cache/apk/*"]
 COPY entrypoint /entrypoint
 
 WORKDIR /entrypoint
 ENV CGO_ENABLED 0
-RUN ["go", "build", "."]
+
+RUN ["go", "build", "-ldflags", "-s -w", "."]
+RUN ["upx", "entrypoint"]
 
 
 FROM alpine as empty


### PR DESCRIPTION
... by using go build -ldflags '-s -w' and upx. (Because we can.)