### PR TITLE
Allow building the container from a checkout created with umask 077

### DIFF
--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -11,11 +11,13 @@ RUN ["go", "build", "-ldflags", "-s -w", "."]
 RUN ["upx", "entrypoint"]
 
 
-FROM alpine as empty
+FROM alpine as base
 RUN ["mkdir", "/empty"]
+COPY rootfs /rootfs
+RUN ["chmod", "-R", "u=rwX,go=rX", "/rootfs"]
 
 
 FROM scratch
-COPY rootfs/ /
-COPY --from=empty --chown=icingadb:icingadb /empty /etc/icingadb
+COPY --from=base /rootfs/ /
+COPY --from=base --chown=icingadb:icingadb /empty /etc/icingadb
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint


### PR DESCRIPTION
Previously, the permissions were just copied from the git checkout, i.e. if this was done with umask 077, files and directories in the container would end up with mode 700 or 600, for example /etc had mode 700.

fixes #16