### PR TITLE
Add --name for icingadb in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run --rm -d \
 docker run -d \
 	--network icinga \
 	--restart always \
-        --name icingadb \
+	--name icingadb \
 	-e ICINGADB_REDIS_HOST=redis-icingadb \
 	-e ICINGADB_REDIS_PORT=6379 \
 	-e ICINGADB_REDIS_PASSWORD=123456 \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Consult the [Icinga DB configuration documentation] on what options there are.
 docker run -d \
 	--network icinga \
 	--restart always \
-        --name icingadb \
+	--name icingadb \
 	-e ICINGADB_REDIS_HOST=redis-icingadb \
 	-e ICINGADB_REDIS_PORT=6379 \
 	-e ICINGADB_REDIS_PASSWORD=123456 \

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ docker run --rm -d \
 docker run -d \
 	--network icinga \
 	--restart always \
+        --name icingadb \
 	-e ICINGADB_REDIS_HOST=redis-icingadb \
 	-e ICINGADB_REDIS_PORT=6379 \
 	-e ICINGADB_REDIS_PASSWORD=123456 \
@@ -56,6 +57,7 @@ Consult the [Icinga DB configuration documentation] on what options there are.
 docker run -d \
 	--network icinga \
 	--restart always \
+        --name icingadb \
 	-e ICINGADB_REDIS_HOST=redis-icingadb \
 	-e ICINGADB_REDIS_PORT=6379 \
 	-e ICINGADB_REDIS_PASSWORD=123456 \


### PR DESCRIPTION
The other containers all have meaningful names, describing what they are. Adding this makes it much easier for people to track the purpose of the container.