### PR TITLE
build.bash: workaround a bug in docker buildx build CLI

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -25,7 +25,7 @@ if ! docker buildx version; then
 fi
 
 OUR_DIR="$(realpath "$(dirname "$0")")"
-COMMON_ARGS=(-t "icinga/icingadb:$TAG" --build-context "icingadb-git=$(realpath "$IDBSRC")/.git" "$OUR_DIR")
+COMMON_ARGS=(-t "icinga/icingadb:$TAG" --build-context "icingadb-git=$(realpath "$IDBSRC")/.git/" "$OUR_DIR")
 BUILDX=(docker buildx build --platform "$(cat "${OUR_DIR}/platforms.txt")")
 
 case "$ACTION" in


### PR DESCRIPTION
--build-context dirs seem to have to end with a / to be accepted.

Just like https://github.com/Icinga/docker-icinga2/pull/119