### PR TITLE
README.md: usage example: protect Redis with the password used by Icinga DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker network create icinga
 docker run --rm -d \
 	--network icinga \
 	--name redis-icingadb \
-	redis
+	redis redis-server --requirepass 123456
 
 docker run --rm -d \
 	--network icinga \


### PR DESCRIPTION
Otherwise Redis complains:

ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?

fixes #51