### PR TITLE
entrypoint/: process config env vars with "-" as well

### DIFF
--- a/entrypoint/main.go
+++ b/entrypoint/main.go
@@ -24,7 +24,7 @@ import (
 const configDir = "/etc/icingadb"
 
 var config = path.Join(configDir, "icingadb.yml")
-var myEnv = regexp.MustCompile(`(?s)\AICINGADB_(\w+?)_(\w+)=(.*)\z`)
+var myEnv = regexp.MustCompile(`(?s)\AICINGADB_([-\w]+?)_([-\w]+)=(.*)\z`)
 
 var log = func() *zap.Logger {
 	logger, err := zap.NewDevelopment()


### PR DESCRIPTION
to support config options with "-" in names.

fixes #58