### PR TITLE
Add Labels to Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM scratch
 
 LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db' \
       org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
-      org.opencontainers.image.licenses='GPL-2.0+'
+      org.opencontainers.image.licenses='GPL-2.0-or-later'
 
 COPY --from=base /rootfs/ /
 COPY --from=base --chown=icingadb:icingadb /empty /etc/icingadb

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN ["chmod", "-R", "u=rwX,go=rX", "/rootfs"]
 
 FROM scratch
 
+LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db/latest/doc/01-About/' \
+      org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
+      org.opencontainers.image.licenses='GPL-2.0+'
+
 COPY --from=base /rootfs/ /
 COPY --from=base --chown=icingadb:icingadb /empty /etc/icingadb
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN ["chmod", "-R", "u=rwX,go=rX", "/rootfs"]
 
 FROM scratch
 
-LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db/latest/doc/01-About/' \
+LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db' \
       org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
       org.opencontainers.image.licenses='GPL-2.0+'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ FROM scratch
 
 LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db' \
       org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
+      org.opencontainers.image.url='https://github.com/Icinga/docker-icingadb' \
       org.opencontainers.image.licenses='GPL-2.0-or-later' \
       org.opencontainers.image.title='Icinga DB' \
       org.opencontainers.image.vendor='Icinga GmbH'

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ FROM scratch
 
 LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db' \
       org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
-      org.opencontainers.image.licenses='GPL-2.0-or-later'
+      org.opencontainers.image.licenses='GPL-2.0-or-later' \
+      org.opencontainers.image.title='Icinga DB' \
+      org.opencontainers.image.vendor='Icinga GmbH'
 
 COPY --from=base /rootfs/ /
 COPY --from=base --chown=icingadb:icingadb /empty /etc/icingadb


### PR DESCRIPTION
As a user I want to know where stuff in my image came from. Those standardized tags allow automated tools to find the source code. For instance, this will allow renovate bot to show a changelog (based on the github releases) and provide a nice link to the repo.